### PR TITLE
Fixed references to non-existent values in RuleMetaData

### DIFF
--- a/tools/render-rules.ts
+++ b/tools/render-rules.ts
@@ -102,7 +102,7 @@ function createDeprecationTable(
       meta.docs.ruleName || ""
     )})`;
 
-    const replacedRules = meta.docs.replacedBy || [];
+    const replacedRules = meta.replacedBy || [];
     const replacedBy = replacedRules
       .map((name) => `[css/${name}](${buildRulePath(name)})`)
       .join(", ");


### PR DESCRIPTION
Hello .
Fixed a reference to a non-existent value in render-rules.ts if the type definition of RuleMetaData is correct.

Sorry for the small correction, but please confirm.